### PR TITLE
ENH: braycurtis -> bray_curtis

### DIFF
--- a/q2_boots/_core_metrics.py
+++ b/q2_boots/_core_metrics.py
@@ -26,7 +26,7 @@ def core_metrics(ctx, table, sampling_depth, metadata, n, replacement,
     emperor_plot_action = ctx.get_action('emperor', 'plot')
 
     alpha_metrics = ['pielou_e', 'observed_features', 'shannon']
-    beta_metrics = ['braycurtis', 'jaccard']
+    beta_metrics = ['bray_curtis', 'jaccard']
     if phylogeny is not None:
         alpha_metrics.append('faith_pd')
         beta_metrics.extend(['unweighted_unifrac', 'weighted_unifrac'])

--- a/q2_boots/_examples.py
+++ b/q2_boots/_examples.py
@@ -99,13 +99,13 @@ def _beta_bootstrap_example(use):
         use.UsageAction(plugin_id='boots',
                         action_id='beta'),
         use.UsageInputs(table=table,
-                        metric='braycurtis',
+                        metric='bray_curtis',
                         sampling_depth=20,
                         n=10,
                         replacement=True,
                         average_method='medoid'),
         use.UsageOutputNames(
-            average_distance_matrix='braycurtis_bootstrapped')
+            average_distance_matrix='bray_curtis_bootstrapped')
     )
 
 
@@ -117,12 +117,12 @@ def _beta_rarefaction_example(use):
                         action_id='beta'),
         use.UsageInputs(table=table,
                         sampling_depth=20,
-                        metric='braycurtis',
+                        metric='bray_curtis',
                         n=10,
                         replacement=False,
                         average_method='medoid'),
         use.UsageOutputNames(
-            average_distance_matrix='braycurtis_rarefaction')
+            average_distance_matrix='bray_curtis_rarefaction')
     )
 
 


### PR DESCRIPTION
Okay, so this is pretty nitpicky but Bray Curtis is the only metric that is multiple words that is written without a `_`. 

So I think we should change this for consistancy's sake: braycurtis -> bray_curtis. 

Feel free to close this PR if this is a known nomenclature. It seemed easier to cut a PR vs making an issue 