### PR TITLE
IMP: integrate vizard scatter plot generation in core-metrics

### DIFF
--- a/q2_boots/_core_metrics.py
+++ b/q2_boots/_core_metrics.py
@@ -53,6 +53,7 @@ def core_metrics(ctx, table, sampling_depth, metadata, n, replacement,
         avg_alpha_vector, = alpha_average_action(
             alpha_collection, alpha_average_method)
         alpha_vectors[alpha_metric] = avg_alpha_vector
+        metadata = avg_alpha_vector.view(Metadata).merge(metadata)
 
     beta_dms = {}
     for beta_metric in beta_metrics:

--- a/q2_boots/_core_metrics.py
+++ b/q2_boots/_core_metrics.py
@@ -6,6 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+from skbio import OrdinationResults
+from qiime2 import Metadata
+import numpy as np
 from q2_boots._alpha import (_validate_alpha_metric, _get_alpha_metric_action,
                              _alpha_collection_from_tables)
 from q2_boots._beta import (_validate_beta_metric, _get_beta_metric_action,
@@ -14,13 +17,15 @@ from q2_boots._beta import (_validate_beta_metric, _get_beta_metric_action,
 
 def core_metrics(ctx, table, sampling_depth, metadata, n, replacement,
                  phylogeny=None, alpha_average_method='median',
-                 beta_average_method='non-metric-median'):
+                 beta_average_method='non-metric-median', pc_dimensions=3,
+                 color_by=None):
 
     resample_action = ctx.get_action('boots', 'resample')
     alpha_average_action = ctx.get_action('boots', 'alpha_average')
     beta_average_action = ctx.get_action('boots', 'beta_average')
     pcoa_action = ctx.get_action('diversity', 'pcoa')
     emperor_plot_action = ctx.get_action('emperor', 'plot')
+    scatter_action = ctx.get_action('vizard', 'scatterplot_2d')
 
     alpha_metrics = ['pielou_e', 'observed_features', 'shannon']
     beta_metrics = ['braycurtis', 'jaccard']
@@ -68,4 +73,20 @@ def core_metrics(ctx, table, sampling_depth, metadata, n, replacement,
                                             metadata=metadata)
         emperor_plots[key] = emperor_plot
 
-    return resampled_tables, alpha_vectors, beta_dms, pcoas, emperor_plots
+    for pcoa, name in zip(pcoas.values(), beta_metrics):
+        pc_result = pcoa.view(OrdinationResults)
+        prop_explained = pc_result.proportion_explained[:pc_dimensions].values
+        # replace nan with 0.0 (indicating no variation explained) - this
+        # prevents failure in situations of extreme low diversity (like the
+        # usage example), and only impacts the scatter plot (not the actual
+        # ordination results being produced by the action)
+        prop_explained = np.nan_to_num(prop_explained)
+        pc_result = pcoa.view(Metadata).to_dataframe().iloc[:, :pc_dimensions]
+        pc_result.columns = ['{0} {1} ({2}%)'.format(name, c, int(p * 100)) for
+                             c, p in zip(pc_result.columns, prop_explained)]
+        metadata = Metadata(pc_result).merge(metadata)
+
+    scatter_plot, = scatter_action(metadata=metadata, color_by=color_by)
+
+    return (resampled_tables, alpha_vectors, beta_dms, pcoas, emperor_plots,
+            scatter_plot)

--- a/q2_boots/_examples.py
+++ b/q2_boots/_examples.py
@@ -167,7 +167,8 @@ def _core_metrics_bootstrap_example(use):
             alpha_diversities='bootstrap_alpha_diversities',
             distance_matrices='bootstrap_distance_matrices',
             pcoas='bootstrap_pcoas',
-            emperor_plots='bootstrap_emperor_plots'
+            emperor_plots='bootstrap_emperor_plots',
+            scatter_plot='scatter_plot'
             )
     )
 
@@ -191,7 +192,8 @@ def _core_metrics_rarefaction_example(use):
             alpha_diversities='rarefaction_alpha_diversities',
             distance_matrices='rarefaction_distance_matrices',
             pcoas='rarefaction_pcoas',
-            emperor_plots='rarefaction_emperor_plots'
+            emperor_plots='rarefaction_emperor_plots',
+            scatter_plot='scatter_plot'
             )
     )
 

--- a/q2_boots/plugin_setup.py
+++ b/q2_boots/plugin_setup.py
@@ -67,6 +67,15 @@ _replacement_description = (
     'Resample `table` with replacement (i.e., bootstrap) or without '
     'replacement (i.e., rarefaction).')
 _resampled_tables_description = 'The `n` resampled tables.'
+_pc_dimensions_description = (
+    'Number of principal coordinate dimensions to present in the 2D '
+    'scatterplot.')
+_color_by_description = (
+    'Categorical measure from the input Metadata that should be used for '
+    'color-coding the 2D scatterplot.')
+_scatter_plot_description = (
+    '2D scatter plot including alpha diversity and pcoa results for all '
+    'selected metrics.')
 
 # Resampling
 
@@ -363,10 +372,8 @@ plugin.pipelines.register_function(
         'alpha_average_method': 'Method to use for averaging alpha diversity.',
         'beta_average_method': 'Method to use for averaging beta diversity.',
         'replacement': _replacement_description,
-        'pc_dimensions': 'Number of principal coordinate dimensions to keep '
-                         'for plotting.',
-        'color_by': 'Categorical measure from the input Metadata that '
-                    'should be used for color-coding the scatterplot.'
+        'pc_dimensions': _pc_dimensions_description,
+        'color_by': _color_by_description
     },
     output_descriptions={
         'resampled_tables': _resampled_tables_description,
@@ -375,8 +382,7 @@ plugin.pipelines.register_function(
                               'each metric.'),
         'pcoas': 'PCoA matrix for each beta diversity metric.',
         'emperor_plots': 'Emperor plot for each beta diversity metric.',
-        'scatter_plot': ('Scatter plot including alpha diversity and '
-                         'pcoa results for all selected metrics.')
+        'scatter_plot': _scatter_plot_description
     },
     name='Perform resampled "core metrics" analysis.',
     description=('Given a single feature table as input, this action resamples '
@@ -387,7 +393,9 @@ plugin.pipelines.register_function(
                  'specified by `alpha_average_method` and '
                  '`beta_average_method` parameters. The resulting average '
                  'alpha and beta diversity artifacts are returned, along with '
-                 'PCoA matrices and Emperor plots.'),
+                 'PCoA matrices, Emperor plots, and a 2D scatter plot '
+                 'including alpha diversity values and PCoA of all beta '
+                 'diversity metrics.'),
     examples={
         'Bootstrapped core metrics.': _core_metrics_bootstrap_example,
         'Rarefaction-based core metrics.': _core_metrics_rarefaction_example
@@ -463,10 +471,8 @@ plugin.pipelines.register_function(
         'norm': 'Normalization procedure applied to TF-IDF scores. Ignored '
                 'if tfidf=False. l2: Sum of squares of vector elements is 1. '
                 'l1: Sum of absolute values of vector elements is 1.',
-        'pc_dimensions': 'Number of principal coordinate dimensions to keep '
-                         'for plotting.',
-        'color_by': 'Categorical measure from the input Metadata that '
-                    'should be used for color-coding the scatterplot.'
+        'pc_dimensions': _pc_dimensions_description,
+        'color_by': _color_by_description
     },
     output_descriptions={
         'resampled_tables': _resampled_tables_description,
@@ -475,8 +481,7 @@ plugin.pipelines.register_function(
         'distance_matrices': ('Average beta diversity distance matrix for '
                               'each metric.'),
         'pcoas': 'PCoA matrix for each beta diversity metric.',
-        'scatter_plot': ('Scatter plot including alpha diversity and '
-                         'pcoa results for all selected metrics.')
+        'scatter_plot': _scatter_plot_description
     },
     name='Perform resampled "core metrics" analysis on kmerized features.',
     description=('Given a single feature table as input, this action resamples '

--- a/q2_boots/plugin_setup.py
+++ b/q2_boots/plugin_setup.py
@@ -343,7 +343,9 @@ plugin.pipelines.register_function(
         'beta_average_method': Str % Choices('non-metric-mean',
                                              'non-metric-median',
                                              'medoid'),
-        'replacement': Bool
+        'replacement': Bool,
+        'pc_dimensions': Int,
+        'color_by': Str
     },
     outputs=[
         ('resampled_tables', Collection[FeatureTable[Frequency]]),
@@ -351,6 +353,7 @@ plugin.pipelines.register_function(
         ('distance_matrices', Collection[DistanceMatrix]),
         ('pcoas', Collection[PCoAResults]),
         ('emperor_plots', Collection[Visualization]),
+        ('scatter_plot', Visualization),
     ],
     input_descriptions=_diversity_input_descriptions,
     parameter_descriptions={
@@ -359,7 +362,11 @@ plugin.pipelines.register_function(
         'sampling_depth': _sampling_depth_description,
         'alpha_average_method': 'Method to use for averaging alpha diversity.',
         'beta_average_method': 'Method to use for averaging beta diversity.',
-        'replacement': _replacement_description
+        'replacement': _replacement_description,
+        'pc_dimensions': 'Number of principal coordinate dimensions to keep '
+                         'for plotting.',
+        'color_by': 'Categorical measure from the input Metadata that '
+                    'should be used for color-coding the scatterplot.'
     },
     output_descriptions={
         'resampled_tables': _resampled_tables_description,
@@ -367,7 +374,9 @@ plugin.pipelines.register_function(
         'distance_matrices': ('Average beta diversity distance matrix for '
                               'each metric.'),
         'pcoas': 'PCoA matrix for each beta diversity metric.',
-        'emperor_plots': 'Emperor plot for each beta diversity metric.'
+        'emperor_plots': 'Emperor plot for each beta diversity metric.',
+        'scatter_plot': ('Scatter plot including alpha diversity and '
+                         'pcoa results for all selected metrics.')
     },
     name='Perform resampled "core metrics" analysis.',
     description=('Given a single feature table as input, this action resamples '

--- a/q2_boots/tests/test_core_metrics.py
+++ b/q2_boots/tests/test_core_metrics.py
@@ -8,6 +8,7 @@
 
 import qiime2
 from qiime2.plugin.testing import TestPluginBase
+from qiime2.plugin import Visualization
 import pandas as pd
 import pandas.testing as pdt
 import skbio
@@ -72,6 +73,9 @@ class CoreMetricsTests(TestPluginBase):
                                                 ids=['S1', 'S2'])
         observed_jaccard = output[2]['jaccard'].view(skbio.DistanceMatrix)
         self.assertEqual(observed_jaccard, expected_jaccard)
+
+        # vizard scatter plot returned
+        self.assertEqual(output[5].type, Visualization)
 
     def test_core_metrics_w_replacement(self):
         output = self.core_metrics(table=self.table1,
@@ -139,6 +143,9 @@ class CoreMetricsTests(TestPluginBase):
                         msg=(f"Median value ({observed_jaccard[('S1', 'S2')]}) "
                              "is not equal to 0.0, 0.5 or 1.0."))
 
+        # vizard scatter plot returned
+        self.assertEqual(output[5].type, Visualization)
+
     def test_core_metrics_phylogenetic(self):
         output = self.core_metrics(table=self.table1,
                                    phylogeny=self.phylogeny,
@@ -192,3 +199,6 @@ class CoreMetricsTests(TestPluginBase):
             output[2]['unweighted_unifrac'].view(skbio.DistanceMatrix)
         self.assertEqual(observed_unweighted_unifrac,
                          expected_unweighted_unifrac)
+
+        # vizard scatter plot returned
+        self.assertEqual(output[5].type, Visualization)

--- a/q2_boots/tests/test_kmer_diversity.py
+++ b/q2_boots/tests/test_kmer_diversity.py
@@ -74,7 +74,7 @@ class KmerDiversityTests(TestPluginBase):
         observed_obs_features = output[2]['observed_features'].view(pd.Series)
         pdt.assert_series_equal(observed_obs_features, expected_obs_features)
 
-        # expected dms, pcoas, and plots returned
+        # expected dms and pcoas returned
         self.assertEqual(set(output[3].keys()), set(['jaccard', 'braycurtis']))
         self.assertEqual(set(output[4].keys()), set(['jaccard', 'braycurtis']))
 


### PR DESCRIPTION
This adds the vizard scatter plot generation to the `core-metrics` workflow - it's convenient to have this as it lets you look at all of the beta diversity values in a single plot. Emperor plots are still generated. 

Screenshot of an example plot:
<img width="1616" height="1253" alt="screenshot 2025-07-15 at 12 55 24 PM" src="https://github.com/user-attachments/assets/d25a0172-db88-4819-935b-c8ead82329c4" />
